### PR TITLE
fix(webpack): should resolve plugins installed in slim project

### DIFF
--- a/src/webpack/webpack.config.common.ts
+++ b/src/webpack/webpack.config.common.ts
@@ -8,6 +8,10 @@ export function getCommonConfigPartial(indexPath: string, environment: any, conf
             extensions: [".ts", ".js", ".json"],
             modules: ["node_modules", path.resolve(__dirname, path.join(config.rootDir, "node_modules"))]
         },
+        resolveLoader: {
+            extensions: [".js"],
+            modules: ["node_modules", path.resolve(__dirname, "../../", "node_modules")]
+        },
         module: {
             rules: [
                 {


### PR DESCRIPTION
Should resolve configured WebPack-Plugins through _node_modules_ present in slim-directory, so consuming projects don't need to (re)-install the Plugins.