### PR TITLE
fix(webpack): add option to exclude packages with errors in their source maps

### DIFF
--- a/src/config/slim-config/slim-config.defaults.ts
+++ b/src/config/slim-config/slim-config.defaults.ts
@@ -30,5 +30,11 @@ export const defaultSlimConfig: SlimConfig = {
     },
     extras: {
         entries: []
+    },
+    webpack: {
+        ignoreSourceMaps: [
+            "ionic-angular",
+            "ionic-native"
+        ]
     }
 };

--- a/src/config/slim-config/slim-config.ts
+++ b/src/config/slim-config/slim-config.ts
@@ -58,6 +58,17 @@ export declare interface SlimConfig {
     };
 
     /**
+     * Webpack settings
+     */
+    webpack?: {
+
+        /**
+         * Ignore these modules because they have errors in their source maps.
+         */
+        ignoreSourceMaps: string[]
+    };
+
+    /**
      * TypeScript settings.
      */
     typescript?: {

--- a/src/webpack/webpack.config.common.ts
+++ b/src/webpack/webpack.config.common.ts
@@ -60,7 +60,8 @@ export function getCommonConfigPartial(indexPath: string, environment: any, conf
                     test: /\.js$/,
                     loader: "source-map-loader",
                     exclude: [
-                        /ionic-angular/
+                        /ionic-angular/,
+                        /ionic-native/
                     ]
                 },
                 { test: /\.json$/, loader: "json-loader" },

--- a/src/webpack/webpack.config.common.ts
+++ b/src/webpack/webpack.config.common.ts
@@ -59,10 +59,7 @@ export function getCommonConfigPartial(indexPath: string, environment: any, conf
                 {
                     test: /\.js$/,
                     loader: "source-map-loader",
-                    exclude: [
-                        /ionic-angular/,
-                        /ionic-native/
-                    ]
+                    exclude: config.webpack.ignoreSourceMaps
                 },
                 { test: /\.json$/, loader: "json-loader" },
                 { test: /\.html/, loader: "raw-loader", exclude: [indexPath] },


### PR DESCRIPTION
This fixes the following warnings:
```
WARNING in ./~/ionic-native/dist/esm/plugins/zip.js
Cannot find source file '../../../src/plugins/zip.ts': Error: Can't resolve '../../../src/plugins/zip.ts' in '/Some/Project/node_modules/ionic-native/dist/esm/plugins'
 @ ./~/ionic-native/dist/esm/index.js 110:0-36 219:0-30
 @ ./src/login/login-page.component.ts
 @ ./src/login/index.ts
 @ ./src/app/app.module.ts
 @ ./src/bootstrap.ts
 @ multi webpack-dev-server/client?http://localhost:8000/ webpack/hot/only-dev-server ./src/bootstrap.ts
```