### PR TITLE
feat(codesplit): add behaviour to split code into app, manifest and vendor bundles

### DIFF
--- a/project-typings/cli-typings.d.ts
+++ b/project-typings/cli-typings.d.ts
@@ -6,6 +6,7 @@ declare interface Options {
     app?: boolean;
     minify?: boolean;
     aot?: boolean;
+    codesplit?: boolean;
     serve?: boolean;
     open?: boolean;
     watch?: boolean;

--- a/src/commands/build.command.ts
+++ b/src/commands/build.command.ts
@@ -22,6 +22,10 @@ export const buildCommand: yargs.CommandModule = {
         "skip-sourcemaps": {
             type: "boolean",
             description: "Skip sourcemap generation."
+        },
+        "codesplit": {
+            type: "boolean",
+            description: "Split code into app, manifest and vendor bundles."
         }
     },
     handler: (options: Options) => {
@@ -32,9 +36,9 @@ export const buildCommand: yargs.CommandModule = {
         const buildTask = require("../tasks/build.task");
         const serveTask = require("../tasks/serve.task");
         if (options.serve) {
-            exitCode = buildTask(environmentVariables, slimConfig, options.minify, options.aot, options["skip-sourcemaps"]).then(() => serveTask(environmentVariables, slimConfig, options.open));
+            exitCode = buildTask(environmentVariables, slimConfig, options.minify, options.aot, options["skip-sourcemaps"], options.codesplit).then(() => serveTask(environmentVariables, slimConfig, options.open));
         } else {
-            exitCode = buildTask(environmentVariables, slimConfig, options.minify, options.aot, options["skip-sourcemaps"]);
+            exitCode = buildTask(environmentVariables, slimConfig, options.minify, options.aot, options["skip-sourcemaps"], options.codesplit);
         }
         exitCode
             .then(code => {

--- a/src/webpack/plugins/chunk.plugin.ts
+++ b/src/webpack/plugins/chunk.plugin.ts
@@ -1,0 +1,7 @@
+import * as webpack from "webpack";
+
+export const extractBundles = (bundles) => ({
+  plugins: bundles.map((bundle) => (
+    new webpack.optimize.CommonsChunkPlugin(bundle)
+  )),
+});


### PR DESCRIPTION
Slim should be able to split the produced bundles into seperate files, to optimize load/parse times on mobiles.